### PR TITLE
fix def calculateMdmDeviatn

### DIFF
--- a/rflib/chipcon_nic.py
+++ b/rflib/chipcon_nic.py
@@ -965,9 +965,9 @@ class NICxx11(USBDongle):
         if baud <= 2400:
             deviatn = 5100
         elif baud <= 38400:
-            deviatn = 20000 * (old_div((baud-2400),36000))
+            deviatn = 20000 * (((baud-2400) / 36000))
         else:
-            deviatn = 129000 * (old_div((baud-38400),211600))
+            deviatn = 129000 * (((baud-38400) / 211600))
         self.setMdmDeviatn(deviatn)
 
     def calculatePktChanBW(self, mhz=24, radiocfg=None):


### PR DESCRIPTION
old_div is doing something funky here. 

When extracting and running just this function and printing deviatn, all baud that *should* fall in these are zero.

elif baud <= 38400:
    deviatn = 20000 * (old_div((baud-2400),36000))
else:
    deviatn = 129000 * (old_div((baud-38400),211600))

by changing it to normal division it returns much more reasonable results